### PR TITLE
Use proxy_pass for everything except selfchecks

### DIFF
--- a/default.conf.template
+++ b/default.conf.template
@@ -14,7 +14,7 @@ server {
         add_header Content-Type text/plain;
    }
 
-   location /api/ {
+   location / {
        proxy_pass ${SERVICE_GATEWAY_URL};
        proxy_set_header x-nav-apiKey ${SERVICE_GATEWAY_KEY};
    }


### PR DESCRIPTION
This should make it so every request to syfoteksterproxy will be proxied and will allow getting the /api resource. However this may not be an ideal solution as we really only want /api to be passed through. We could also match on `location = /api` and `location /api` with the same block. But my preferred solution would be to change syfotekster to provide the json at a sub path of `/api` like: `/api/tekster.json`.